### PR TITLE
Color output and print diff.

### DIFF
--- a/diff-match-patch.asd
+++ b/diff-match-patch.asd
@@ -11,7 +11,7 @@
   :author "Neil Fraser; ported by Boris Smilga"
   :maintainer "Boris Smilga <boris.smilga@gmail.com>"
   :license "Apache 2.0"
-  :depends-on (#:iterate #:cl-ppcre)
+  :depends-on (#:iterate #:cl-ppcre #:cl-ansi-text)
   :components
     ((:module #:src
         :serial t
@@ -22,7 +22,8 @@
            (:file "diff")
            (:file "cleanup")
            (:file "match")
-           (:file "patch")))))
+           (:file "patch")
+           (:file "print")))))
 
 (defsystem #:diff-match-patch.test
   :name "Diff/Match/Patch tests"

--- a/lib.lisp
+++ b/lib.lisp
@@ -171,9 +171,8 @@
           (write-char (hexc i) out)
           (write-char (hexc j) out)))))
 
-(defun write-line-urlencode (line out)
-  (iter (for c :in-string line) (write-char-urlencode c out)
-        (finally (terpri out))))
+(defun write-string-urlencode (string out)
+  (iter (for c :in-string string) (write-char-urlencode c out)))
 
 (defun read-char-urldecode (in)
   (flet ((read-hex ()

--- a/package.lisp
+++ b/package.lisp
@@ -33,7 +33,9 @@
            #:hunk-length-a #:hunk-length-b
            #:make-patch #:apply-patch
            #:write-chars-patch #:read-chars-patch
-           #:write-lines-patch #:read-lines-patch))
+           #:write-lines-patch #:read-lines-patch
+           ;; print.lisp
+           #:print-diff))
 
 ;;;; Global parameters ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/print.lisp
+++ b/print.lisp
@@ -1,0 +1,25 @@
+(in-package #:diff-match-patch)
+
+(defun print-diff (a b &key (test #'eql) (out *standard-output*) (format :plain) (color T))
+  "Runs (DIFF A B) and prints the diff in a pretty format.  FORMAT can be
+   :PLAIN to indicate additions and removals by {+...+} and [-...-], or NIL
+   if not.  COLOR indicates whether to enabled colored output via ANSI
+   escape codes."
+  (iter
+    (for (op x) in (diff a b :test test))
+    (when color
+      (case op
+        (:+ (write-string #.(cl-ansi-text:make-color-string :green) out))
+        (:- (write-string #.(cl-ansi-text:make-color-string :red) out))))
+    (when (eq format :plain)
+      (case op
+        (:+ (write-string "{+" out))
+        (:- (write-string "[-" out))))
+    (format out "~A" x)
+    (when (eq format :plain)
+      (case op
+        (:+ (write-string "+}" out))
+        (:- (write-string "-]" out))))
+    (when color
+      ;; TODO: could be optimised to only reset if necessary
+      (write-string #.cl-ansi-text:+reset-color-string+ out))))


### PR DESCRIPTION
This might be controversial, so if you'd rather have this in a separate ASDF I'd be happy to think about something, however I think having the color output off by default might already be enough backwards compatibility.

`PRINT-DIFF` is a convenience function on the other hand that I'd really like to have for mostly interactive use (e.g. in tests for showing expected vs. actual output).